### PR TITLE
feat: add papers and conference notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ TODO:
 - link to some toy repos of mine
 - link to my "publications" (including the software patents while at DynamoDB) 
 
+## Technical Papers & Study Notes
+
+- [EVM Foundations (7-day study guide)](papers/EVM-Foundations.md) — Mental models of EVM execution, storage, state, and gas
+- [Snowflake Paper & Architecture Review](papers/Snowflake-paper.md) — Deep dive into Snowflake's OLAP database architecture
+
+## Conference Talks & Notes
+
+- [QCon London 2020](talks/conferences/2020-qcon-london/) — Notes from various talks
+
 ## About me
 
 I’m Miguel Mascarenhas Filipe, and I like to solve problems so much that one of my mottos is *“problems are waiting to be solved”.* On twitter “Sui *generis, creative & adventurer. Loves distributed systems, hard problems, and First Principles Engineering”*

--- a/papers/EVM-Foundations.md
+++ b/papers/EVM-Foundations.md
@@ -1,0 +1,185 @@
+# EVM Foundations (Days 1–7)
+
+> Goal: build solid mental models of EVM execution, storage, state, and gas—validated by small, real traces on your node.
+
+---
+
+## Prereqs (install any you’re missing)
+
+* **Geth** (or your node with debug/trace APIs): [https://geth.ethereum.org/](https://geth.ethereum.org/)
+* **Foundry (cast/forge)**: [https://book.getfoundry.sh/](https://book.getfoundry.sh/)
+* **Solidity compiler (solc)**: [https://docs.soliditylang.org/en/latest/installing-solidity.html](https://docs.soliditylang.org/en/latest/installing-solidity.html)
+
+---
+
+## Day 1 — Big-picture EVM & “living spec”
+
+**Read**
+
+* EVM overview: [https://ethereum.org/en/developers/docs/evm/](https://ethereum.org/en/developers/docs/evm/)
+* Execution-specs (EELS) README: [https://github.com/ethereum/execution-specs](https://github.com/ethereum/execution-specs)
+* Keep these open while learning:
+
+  * Opcodes (reference): [https://ethereum.org/en/developers/docs/evm/opcodes/](https://ethereum.org/en/developers/docs/evm/opcodes/)
+  * Opcodes (interactive, gas, traces): [https://www.evm.codes/](https://www.evm.codes/)
+
+**Output**
+
+* 1-page notes: account model, call stack vs. memory vs. storage, gas lifecycle, where env/state come from.
+
+---
+
+## Day 2 — Yellow Paper (surgical read)
+
+**Read (targeted)**
+
+* Yellow Paper PDF: [https://ethereum.github.io/yellowpaper/paper.pdf](https://ethereum.github.io/yellowpaper/paper.pdf)
+  Focus: State transition (transactions→blocks), Execution model, Gas, Memory, and the Opcode appendix.
+
+**Output**
+
+* Bullet list of invariants (e.g., call/revert behavior, exceptional halts, memory expansion rules).
+
+---
+
+## Day 3 — Opcodes by category + minimal bytecode
+
+**Read**
+
+* Opcode groups (stack/mem/storage/call/flow/log/precompiles) via: [https://www.evm.codes/](https://www.evm.codes/)
+
+**Hands-on**
+
+```bash
+# Tiny contract → bytecode & opcodes
+printf 'pragma solidity ^0.8.20; contract T { function f(uint x) public pure returns(uint){ return x+1; } }' > T.sol
+solc --bin --opcodes T.sol
+```
+
+**Output**
+
+* 10–15 opcode “flashcards” with purpose + gotcha (e.g., `CALL` gas stipend, `JUMPDEST`, `PUSH0`).
+
+---
+
+## Day 4 — Trace one real mainnet tx end-to-end
+
+**Read**
+
+* JSON-RPC basics: [https://ethereum.org/en/developers/docs/apis/json-rpc/](https://ethereum.org/en/developers/docs/apis/json-rpc/)
+* Geth tracing overview: [https://geth.ethereum.org/docs/developers/evm-tracing](https://geth.ethereum.org/docs/developers/evm-tracing)
+
+**Hands-on (pick a tx hash you care about)**
+
+```bash
+# Inspect tx quickly
+cast tx 0xYOUR_TX_HASH --json | jq '.'
+
+# Geth-style deep trace (call graph)
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'content-type: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"debug_traceTransaction",
+           "params":["0xYOUR_TX_HASH", {"tracer":"callTracer","timeout":"30s"}]}' | jq '.'
+
+# Optional: step-by-step VM trace
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'content-type: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"debug_traceTransaction",
+           "params":["0xYOUR_TX_HASH", {"tracer":"vmTrace","timeout":"30s"}]}' | jq '.'
+```
+
+**Output**
+
+* Short write-up mapping call tree ↔ opcodes/memory/storage deltas for one internal call.
+
+---
+
+## Day 5 — Storage layout, mappings, and proofs
+
+**Read**
+
+* Solidity storage layout: [https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html](https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html)
+  (mappings/dynamic arrays hashing formula)
+* `eth_getProof`: [https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getproof](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getproof)
+
+**Hands-on (ERC-20 balance slot example)**
+
+* For `mapping(address⇒uint)` at slot `p` (often `0`): storage slot = `keccak256(pad32(addr) ++ pad32(p))`
+
+```bash
+# Read a raw storage slot once you've computed it
+cast storage 0xTOKEN_ADDRESS 0xCOMPUTED_SLOT
+# Or raw JSON-RPC
+cast rpc eth_getStorageAt 0xTOKEN_ADDRESS 0xCOMPUTED_SLOT latest
+
+# Get Merkle proof for account + specific storage keys
+cast rpc eth_getProof 0xTOKEN_ADDRESS '["0xCOMPUTED_SLOT"]' latest | jq '.'
+```
+
+**Output**
+
+* One example showing: computed slot → raw 32-byte value → decoded balance (uint256).
+
+---
+
+## Day 6 — Tries & encoding (just enough to reason about state)
+
+**Read**
+
+* Merkle–Patricia Trie: [https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/)
+* RLP: [https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/)
+
+**Hands-on (light)**
+
+```bash
+# Fetch a block header and tx for context
+cast block 17000000 --json | jq '.'
+cast tx 0xYOUR_TX_HASH --json | jq '.'
+```
+
+**Output**
+
+* Diagram that names the tries (state / tx / receipt), and where your Day-5 storage proof sits in the state trie.
+
+---
+
+## Day 7 — Gas you must actually know (post-fork reality)
+
+**Read (EIPs)**
+
+* SSTORE pricing: [https://eips.ethereum.org/EIPS/eip-2200](https://eips.ethereum.org/EIPS/eip-2200)
+* Warm/cold access: [https://eips.ethereum.org/EIPS/eip-2929](https://eips.ethereum.org/EIPS/eip-2929)
+* Refund reductions: [https://eips.ethereum.org/EIPS/eip-3529](https://eips.ethereum.org/EIPS/eip-3529)
+* Access lists: [https://eips.ethereum.org/EIPS/eip-2930](https://eips.ethereum.org/EIPS/eip-2930)
+* Newer opcodes to recognize:
+  `PUSH0` (Shanghai) [https://eips.ethereum.org/EIPS/eip-3855](https://eips.ethereum.org/EIPS/eip-3855)
+  `MCOPY` (Shanghai) [https://eips.ethereum.org/EIPS/eip-5656](https://eips.ethereum.org/EIPS/eip-5656)
+  `TLOAD`/`TSTORE` (Cancun) [https://eips.ethereum.org/EIPS/eip-1153](https://eips.ethereum.org/EIPS/eip-1153)
+
+**Hands-on**
+
+```bash
+# Compare gas behavior via traces for two txs:
+# (1) cold SLOAD/SSTORE vs (2) warmed access or no-op SSTORE
+# Use callTracer/vmTrace from Day 4 and note gas deltas at the op level.
+```
+
+**Output**
+
+* Table with 3 rows: memory expansion cost example, SSTORE (0→non-0 vs non-0→non-0), cold→warm access delta.
+
+---
+
+## Optional quick references
+
+* EVM From Scratch (stepwise, multi-lang): [https://www.evm-from-scratch.xyz/](https://www.evm-from-scratch.xyz/)
+* EIP index (when you hear an opcode/fork name): [https://eips.ethereum.org/](https://eips.ethereum.org/)
+* evm.codes playground (paste bytecode, step it): [https://www.evm.codes/playground](https://www.evm.codes/playground)
+
+---
+
+## What’s next (use your codebase/tests)
+
+* Map your C++ EVMC/evmONE boundaries, then replay the Day-4 tx with your internal parallel re-execution + tracers.
+* Cross-check side effects and gas accounting against geth’s traces.
+

--- a/papers/Snowflake-paper.md
+++ b/papers/Snowflake-paper.md
@@ -1,0 +1,156 @@
+# Snowflake Paper and Architecture Review
+
+- [Snowflake Paper](https://www.snowflake.com/wp-content/uploads/2019/06/Snowflake_SIGMOD.pdf)
+- Andi Pavlo's lecture from spring 2023:
+  - [Youtube, Lecture](https://www.youtube.com/watch?v=bveqnSk15JQ)
+  - [Slides] (https://15721.courses.cs.cmu.edu/spring2023/slides/21-snowflake.pdf)
+    
+## Intro
+
+Snowflake was a wilful investment decision to make a bleeding edge from scratch OLAP database built for SaaS.
+Hired very senior engineers from Oracle and Vectorwise.
+Developed in C++, intention to have a scalable, vectorized OLAP database built on top of cloud.
+Fully built from scratch, full control. (This is known as a "greenfield" design, no baggage, no legacy)
+
+Some quick highlights:
+- Distributed Database, multiple worker nodes
+- Disaggregated Storage
+- Separates fully data from metadata
+- In C++, full control of memory, compiled code (no JVM)
+- Columnar Storage (PAX-style format)
+- Unified Query Optmizer + Adaptive planner (can change plans)
+- Pre-compiled code for vectorized operations on specific primitives (with type specialization)
+- No concept of a shared cache or buffer-pool (more on this later)
+
+(Credit to Andi Pavlo's lectures on this)
+
+
+## High Level Architecture
+
+- Data Storage // Storage
+  
+ Remote, S3 etc.. blob store of data files, immutable fuiles, in PAX format (like parquet), micro-partitions ~50-500MB of raw data.
+ Concurrency control logic was engineered accounting for write-once files and ability to range-read of files.
+ Engine can re-write (optimize) data files to for popular workloads.
+ Any type of table mutation is handled by Copy-on-Write.
+
+- Virtual Warehouses // Compute
+
+  Nodes are fully ephemeral & stateless but contain flash-storage which is critical for performance & cost.
+  Designed for agreessive caching of data files, w/ consistent hashing
+  
+  A note about temp data: they mention that they spill-over to s3 for temp-data. So temp-data can be as large as needed.
+  A side-effect of this is: the flash storage is *always* seen as a disposable cache.
+
+  Compute nodes have SSD drives used solely for caching and temp-data. S3 is also used as spill-over of temp-data so that full disks are handled gracefully.
+
+
+- Cloud Services // Control-Plane.
+
+  All business logic is on the Control-Plane:
+   - metadata mgmt, schemas, DDL operations
+   - ACL metadata, encryption, metering, usage metrics..
+  Control-Plane uses a fast, transactional Key-Value store (FoundationDB) for the catalog and all metadata. the "DB" of this OLAP-DB is a NoSQL KV-storage. heheeh
+
+  This component doesn't have SPOFs and will handle all the multitenancy.
+  A single tenant will deploy  "virtual warehouses" where it will run their queries.
+  Tenants have to IMPORT their DATA into snowflake, they can share data across warehouses.
+
+  
+
+### Data and Metadata
+
+Because files are immutable caching is straightforward, their sizes are also optimized for high granularity on caching. Caching a whole file is fine.
+Metadata, schema, file statistics etc.. they are all stored in a fast NoSQL Key-Value storage (Foundation DB).
+So, query planning has access to very low-latency, high-TPS, consistent KV-storage to provide all the information required for planning an execution.
+Workers available and probably even the mapping of data-files to worker-node(s) that is/are responsible for caching that are all available to the scheduler
+This type of information makes sense to keep alive and fresh on their KV-storage, allowing for more optimal task placement and scheduling.
+
+This contrasts with DeltaLog or basic HiveMetastore that only keep some part of this information on the catalog and the catalog is not in a fast-KV storage
+Also not strongly consistent (like files on S3)
+
+So, there are is a huge technical advantage here:
+- the catalog information is in a fast consistent, transactional storage
+- table -> files mapping is present on catalog, fast to read and atomically change
+- the file metadata and statistics is kept on catalog.
+  - on Parquet files this is kept on the file footer.
+- transaction logs, logs, etc.. everything is on FoundationDB.
+
+On worker-nodes:
+- local cache of files and related metadata it has seen before
+- simple LRU is "good enough"
+- brain-less, single "fork" process to process query, knows of sibling worker nodes
+- Data produced can go to temp-files (s3 + cached) or pushed to other nodes (probably just "sinks")
+- "cluster membership" is per-query and is dynamic as workers can die or have other faults.
+
+
+### Elasticity and Isolation
+
+Note that snowflake now has a "serverless" offering, the documented design as a clear allocation and segregation of compute per "warehouse".
+
+The membership worker-nodes of the warehouse is elastic, but there is a membership group across which the caching of data is divided.
+The cache placement uses a consistent-hashing algo, so that we increase the cache hit rate and reduce duplication/wasted flash storage.
+The algo is lazy, when group-membership changes happen, they rely on the cache-replacement algo (LRU) of the local worker node to evict stale files.
+Compute tasks are split per file and sent to the respective owner of that file according to the consistent-hashing.
+
+A Work stealing scheduler used to deal with stragglers or workload in-balances. Dynamically during query execution, workers that finish early will steal work from straggling nodes (taking over remaining files that haven't been processed yet)
+
+They are flexible on the worker-count of a warehouse, if query is taking a long time, more worker-nodes are "borrowed" temporarily to finish the query faster.
+
+Compute elasticity is possible because storage is only a caching optimization, loosely coupled. Any worker-node can work on any file.
+The performance advantage of caching comes from the cache-aware scheduler and having long-lived worker nodes that hold hot-data.
+
+
+
+Data format is columnar, will include column-vector compression and there are additional tricks to work well with nested types.
+
+### The Execution Engine.
+
+(Shorter and more summarized)
+
+Push-based engine, vectorized and columnar data-layout.
+The data-format and RPCs are built in-house and optimized with care.
+
+Push-based engines are common because they maintain a top-coordinator that centralized the plan/control-flow of the execution and parallelize it better.
+In the paper they emphasise better cache efficiency and creating a better DAG-plan instead of a discovered-tree that results from the pull-model.
+This is in contrast with the classically used "vulcano-style" pull-model.
+
+All queries run against a static-map of a files. the workers just work on files and operations over vectors essentially.
+The coordinator/planner is responsible for exploding the catalog, table-versions, schema, logical-plans, file-memberships etc.. and possibly creates:
+- a static, denormalized plan of dags of operations of known discrete types over specific sets of files.
+- the planner uses catalog metadata statistics for pruning the file-list, no secondary-indices, zero user-input.
+- maps the vertices of the dag into worker-nodes, passing "sources" and "sinks", either files or other workers..
+- operations are designed to spill-to-disk, handling mem exhaustion (they expliclity rejected the design of a in-mem-only engine)
+
+
+
+### "Cloud Services"
+
+The highlight of this section for me is:
+- query management and planning relies on pruning and delays "decisions" based on table statistics.
+  I imagine that they delay deciding on the hash/probe side of joins and things like that and re-plan
+  if they discover data-skew or things like that.
+- they combine this w/ prunning and "alway spill-to-disk" choices wisely.
+
+### Highlights
+
+(Mentioned by them)
+1. Web App seen as critical differentiator
+2. "no maintenance" approach: no indices, no tuning, no physical design (partitions..etc..), no vacuum, etc..
+3. Always Up: TL;DR: welcome to the new world, fault tolerant, but full-AZ faults are accepted tradeoff, and would impact users.
+3. Semi-Structured and Schema-Less support becoming more important, performance on "VARIANT"/OBJECT types is very good. ELT vs ETL: they mention the increasing use of Extract + Load.. and only later the "Transform" and the schema design showing up. And the support of OBJECT + procedural UDFs helping users develop ETL tasks.
+4. TimeTravel & Cloning: the usual use of MVCC for providing a way to use a historical version of the data (or un-deleting data)
+5. Data Encryption stuff, (very important for their biz, 
+
+### Final Remarks
+
+1. all metadata on very fast kv-storage, all pruning and statistics per data-file is present
+2. all data on S3 + very agressive/leveraged caching onto local NVMEs
+3. Capacity of a Virtual Warehouse is "bursty" aka dynamic.
+4. No indices, dynamic reallocation of resources to a plan or late-planning, file prunning, work stealing
+5. Columnar store, vectorized engine, C++,  push-based engine, the talks w/ Andi Pavlo has more details on this
+6. Signiffican work on making Documents/JSON/Object very fast by schema discovery and re-conversions
+
+They used a bunch of pages on data encryption.
+
+

--- a/talks/conferences/2020-qcon-london/README.md
+++ b/talks/conferences/2020-qcon-london/README.md
@@ -1,0 +1,16 @@
+# Conference Notes
+
+## 2020 QCon London
+
+Notes from QCon London 2020 - 3 days of talks on distributed systems, ML, engineering culture, and more.
+
+### Day 1
+- [Opening Notes](notes-day1.txt)
+- [Day 1 Talks](day1-*.txt)
+
+### Day 2
+- [Day 2 Notes](notes-day2.txt)
+- [Day 2 Talks](day2-*.txt)
+
+### Day 3
+- [Day 3 Talks](day3-*.txt)

--- a/talks/conferences/2020-qcon-london/day1-IoT-with-less-internet.txt
+++ b/talks/conferences/2020-qcon-london/day1-IoT-with-less-internet.txt
@@ -1,0 +1,26 @@
+
+Internet of Things might have less internet than we thought?
+
+"Think or Thick" cloud architectures.
+
+ML systems have a nice split:
+ - development and then deployment.
+
+ There is a shift of inference into the edge and run the models close to the client.
+
+
+ 7% of companies acknowledge getting value/return from their data science or data-lakes projects.
+
+ "You're being watched. Are you okay with that?"
+
+ lots of problems of privacy, security and even compliance w/ law on IoT stuff and "smart gadgets" like roombas, mobile apps, etc..
+ software & services of modern tools/assets are still property and owned by the company, not the owner.
+ so lots of problems of "accidental" failure due to parent co. stop servicing old products.
+
+ Exposure of the industry failings in regards to change their approach to privacy, security, failure modes, ownership, abandonware.
+ the line of argument is that more enclaving and isolation is going to be a necessary direction as we mature our
+ tech world.
+
+ The final part is: how moving the models and the code to the edge and making it "self hosted" at the edge.
+    massive perf difference, requires TPUs or similar though, aaannd.. quantization of models of course.
+

--- a/talks/conferences/2020-qcon-london/day1-talk2-microservice-decomposition-patterns.txt
+++ b/talks/conferences/2020-qcon-london/day1-talk2-microservice-decomposition-patterns.txt
@@ -1,0 +1,112 @@
+# Author of "Monolith to Microservices" (O'reilly book)
+
+# What is Microservices, what is Monolith?
+- Independent deployability is extremelly valuable.
+- Monolith is the new word for "legacy"
+- Monolith is:
+  - all code packaged into a single packaged unit
+  - all data in single DB
+
+# Types of Monolith ?
+We then have a "modular" monolith.. still bundled and monolithic deployments.
+  - problem is humans aren't very disciplined at designing/maintaining module boundaries.
+
+Another variation is:
+  - Modular Monolith but with modular DB model too.
+      - easier to migrate to microservices (or to fully decouple a module later..)
+  - different teams working on different modules
+
+Another variation is: The distributed Monolith
+  - many binaries, services, databases.
+  - biz-logic is coupled and crosses service boundaries
+  - some features/workstream require a lots of coordination because of boundary crossing
+
+  - high cost of change
+  - large scoped deployments
+  - more to go wrong
+  - release co-ordination
+  - full on distributed system -> 10x worse off
+
+
+A KEY BENEFIT IS: INDEPENDENT DEPLOYABILITY FOR EACH TEAM.
+    having "release trains" is a anti-pattern.
+    they are remedial step before you can have Continuous Delivery.
+
+# How to break down a Monolith
+A key step to reducing and breaking down a monolith (me: lets read legacy, should apply to "u-services" too)
+    is to START WITH DOMAIN DRIVEN DESIGN.
+        obtain DAG of dependencies.
+        -- you now can more easily extract the LEAFs of the DAG.
+    (me: major benefit is properly grasping the dependencies and coupling of modules,
+        so, you can refactor your design by evaluating the DAG and addressing problems it is showing)
+
+# Microservices Should Not Be The Default Choice
+
+"Nobody got fired for buying IBM"
+"Microservices are good, lets use Microservices"
+
+What problems are you trying to solve?
+
+"You won't appreciate the true horror, pain and suffering of microservices until you're running them in production"
+The hard part of it is running it in prod.
+
+"If you do a big bang rewrite, the only thing you get is a big bang" -- Martin Fowler
+
+We need patterns for incremental change
+
+# Strangler Fig Pattern
+1. Identify functionality to move to a new uservice
+2. Redirect calls to new service (move functionality)
+    It might be copy & paste (this means you're in a nice place, becuase the cause is clean to copy out)
+    It is probably to be a re-write or refactor.
+
+    If you can redirect at HTTP level, that's A GREAT APPROACH, numerous HTTP proxies can help you.
+    1. You leave the old code on the monolith, you don't remove it.
+    1. you just redirect transparently to the new service.
+    1. if you have problems, you redirect back to the old system.
+
+# Branch By Abstraction
+1. Same as before
+2. Create an abstraction point (create a call-site)
+  1. it still uses the current code, it is just a facade/API for it.
+3. Create a new service
+  3.1 client code on the monolith implements the abstraction point
+  3.2 implementation is a separate service
+4. Now you put a FREAKIN FEATURE FLAG ON IT
+5. Clean up the old code.
+  5.1: remove the FLAG
+  5.2: delete old code
+
+-- "Working Effectivly with Legacy Code" - Feathers (Michael)
+
+# Parallel Run
+1. Same as before
+2. Same as before
+3. Same as before
+4. CALL BOTH
+5. Compare the results
+ 5.1 error rates?
+ 5.2 latencies? throughput ?
+ 5.3 careful with side effects (only 1 response to the "outside" world)
+
+ GITHUB has code forthis: github.com/github/scientist
+ also other implementations in other languages.
+
+# Separating Deployment from Releasing
+  A lot of the problems of "single deployment" is problems due to releases changed behavoir
+  You can de-risk deployments if you decouple the release of the changed behaviour.
+  Look into progressive delivery (and release flags ?)
+
+# What about Data Access (access the DB is needed?)
+ Avoid sharing databases.
+
+ Expose data in the monolith though direct APIs
+
+ When you have a new owner for the data (the new service)
+ you need to move the data over.
+ what about JOINS?
+    You need to do the JOINs on the application tier.
+    This can create massive latency problems.
+    What used to be a single RTT to the DB is now:
+        2 DB RTTs (in serial) and 1 RTT between the services
+

--- a/talks/conferences/2020-qcon-london/day1-talk3-streaming-millions-likes-per-second.txt
+++ b/talks/conferences/2020-qcon-london/day1-talk3-streaming-millions-likes-per-second.txt
@@ -1,0 +1,94 @@
+This is a story about a real-time platform to have many many ppl interact direclty on live videos.
+
+So, how do you distribute "likes" and other comments to the viewers in real time?
+
+# Challenge 1: The delivery pipe
+
+Doing a like is on a simple HTTP req.
+this goes:
+1. user
+2. likes backend (publish)
+3. streaming service
+4. the receiver.. with a long lived conection to the streaming svc.
+HTTP/1.1 and long-poll with server side events.
+
+    GET / HTTP/1.1
+    Content-Type: text/event-stream
+
+On the client side, this is "EventSource(url)"
+
+# Challenge 2: Connection Management
+They use Akka actors
+each actor has:
+- a mailbox (variable sized fifo)
+- 1 co-routine
+
+There is a supervisor actor that knows the actors that are handling real clients.
+- the publish is done on the supervisor...
+
+# Challenge 3: Multiple Live Videos
+Me: they need just a pubsub.
+clients send a "subscribe(video-id)"
+    there is in-memory subscriptions table where this is tracked.
+        connection-id, video-id
+Supervisor consults this table and selects the child-actors that need to receive
+
+# Challenge 4: 10k concurrent viewers
+A dispatcher pushes to all frontend servers.
+    they created a different pub/sub to know what subscriptions to which video-id, per frontend.
+    so: video-id, frontend-id,subscription-count (only > 0 counts)
+
+# Challenge 5: 100 likes/second
+add more dispatchers.
+Now the pub/sub table must be outside the dispatchers and be shared, so a KV-store.
+
+# Challenge 6: 100 Likes/s, 10000 viewers -> 1M likes/second
+
+Subscription flow:
+1. User subscribes to frontend-node (http)
+1. Frontend subscribes to dispatchers (http)
+1. dispatcher updates the KV-store
+
+Publish flow:
+1. User likes (http)
+1. publish-system is notified (http)
+1. dispatchers are notified (http)
+1. frontends are notified (http)
+1. users are notified (http)
+
+# Challenge 7: LinkedIn adds a new Datacenter.
+
+Publish flow (consumer of like is in different DC)
+1. User likes
+1. publish system is notified
+    1.1 No local-subscribers (local KV-store has zero subscribers)
+    1.2 Dispatch to all peer dispatchers in all DCs
+1. Dispatcher on DC-3 is notified
+1. like before
+1. like before
+
+# Challenge 8: How many persistent connections per Frontend (100k)
+
+This is because frontends do more than just this service
+For a 18M viewers show, 180 machines are enough..
+
+They have a blog post about this.
+
+# Challenge 9: How many events/second on Dispatchers ?
+
+5K events per second, we can publish 50k likes per sec to frontend nodes
+with 10 dispatcher machines.
+the key part here is the fan-out of dispatcher to frontend notifications.
+a single event can have 180 fanout
+
+# Challenge 10: Publish Latency?
+P90 of 75ms
+There are:
++3 network hops: receiving FE to publish system, dispatcher to KV, dispatcher to FE..
+Samza Aeon: tiny.cc/linkedinlatency
+
+# Challenge 11: Presence detection and propagation.
+
+they leveraged Akka framework to track presence of users.
+(very clever and clean way .. don't re-doit, the akka system has to do that work anyways)
+

--- a/talks/conferences/2020-qcon-london/day1-talk4-databases-and-stream-processing.txt
+++ b/talks/conferences/2020-qcon-london/day1-talk4-databases-and-stream-processing.txt
@@ -1,0 +1,99 @@
+A future of consolidation.
+
+By Ben Stopford, office of the CTO, Confluent (the company that maintains Kafka)
+
+# Software is Eating the World
+
+- Weak form: companies are using more software
+- Strong form: companies are BECOMING software
+ We automate the business process away.
+
+ For the weak form you create 3-tier systems: UI + APP-LOGIC + DB
+
+ For the strong from you have: APP + APP... + APP ..
+
+ Compare requesting a ride now to "calling to book a taxi ride"
+
+ "the users of software are going to be more software."
+
+# What about DBs ?
+ Fundamental assumption is that data is PASSIVE.
+
+ Stream databases have a non-static approach
+ You have a stream processor.
+
+ On conventional DB, data is PASSIVE, the query is ACTIVE.
+
+ On even Streams:
+ the data is ACTIVE, the query is PASSIVE
+
+# Streams or Tables ?
+ Event: records the fact that something happened
+  good was sold, a payment was made..etc..
+
+ Events are stage CHANGES, not STATE
+  they carry intent or actions
+
+ Stream is an exact recording of something it happened in the past.
+ A table is your current state
+
+ Stream: immutable, append-only (event has an offset)
+
+ Tables: Mutable, Primary Key (row has a pk)
+
+# Stream-Processors have tables too
+ They input from streams and output to streams
+ But internally use tables
+
+ Stream processors are similar to a materialized view in a DB
+  m-views are synchrounous and are "poll-based"
+  streams are async and push-based
+
+# What about Join?
+  Joining a stream w/ a table..
+   ... straight forward, we enrich the Event, that's it.
+
+  Joining two streams:
+   because systems are async, related events can arrive out of order.
+   The Stream-proc must buffer the stream changes.
+   When all related events are present in a local-state, can a new event be created that represents the join.
+   We need an upper bound on the buffer, lets put an upper bound on:
+    - TIME, using a time-window
+    - some session/correlation-id,start-window,end-window events
+
+# How does this work?
+ - SPs have some materialized-views (tables)
+ - data-partition the streams and SPs, you must partition on same thing so that related events are processed by the same SP.
+ - Broadcast data, creating a global table in practice.
+
+# there is possibly a unified model of DBs.
+  1. allow for active and passive data
+  1. allow for active and passive queries
+
+Standard Query:
+- all the past until now
+Standard Stream Query:
+- from now onto forever
+
+Dashboard Query:
+- from the past until now
+- and carry on updating it in through the future
+
+# Imagine the future.
+
+Normal queries and also: "Push Query":
+> SELECT * from orders where value_ammount > k PUSH CHANGES
+
+Pipelines: keep triggering and pushing events, and reacting downstream..
+
+# Variants:
+
+Most stream systems have SPs and are programming frameworks.
+  - storm, flink, kafka streams.
+Active Databases:
+ - mongo, Couchbase, rethinkdb
+
+
+
+
+

--- a/talks/conferences/2020-qcon-london/day1-talk5-from-batch-to-streaming-to-both.txt
+++ b/talks/conferences/2020-qcon-london/day1-talk5-from-batch-to-streaming-to-both.txt
@@ -1,0 +1,116 @@
+From batch to streaming to both to streaming ... again?
+
+# From the Data Platform Tribe at Skyscanner (Herman Schaaf, Principal Eng)
+
+# Where does the money come from ?
+
+Messages per secon through the data platform.
+.. at 2019.. > 2 Million / sec
+172 Billion events per day.
+
+They also have a OLAP DB, nicknamed "the cube" :-)
+They didn't wanna wait 24h for the ETL cycle to complete.
+
+# From Batch to Streaming
+they started with Kafka topics
+- protobuf messages (all events in protobuf, they really recommend going with something like that)
+- we can then consume and split out into:
+ - metrics to OpenTSDB/Grafana
+ - business events to S3
+ - logs to elastic search
+
+So:
+- decoupled on the event emission
+- coupled on the processing ofthe events
+
+The ended up having servers connected to kafka too and "apache samza"
+So, kafka became their "Single Unified Log"
+
+.. they were quite happy with this..
+... but now we need to have some type of transformations on the events..
+
+With Samza, they could very quickly get Stream Processors up and running.
+
+# some experiences with Kafka in prod.
+they discovered that putting a frontend on front of kafka they protected the kafka cluster from "chatter" around metadata of publishers or subscribers coming and going with deployments/rollouts..
+Also, they could *enforce* their conventions about kafka events.
+So, "having a HTTP proxy to front their Kafka was a really good move"
+
+# Failure because of Success
+So, ppl are using them, they have ~300k events/sec
+
+A mushrooming of Samza jobs meant a single event would have a throughput amplification of pretty much 5x or similar due to SPs.
+and then they needed extra logic to DEDUP events.
+
+# Conways law
+The full business logic of the agregated stream processing they had, didn't have a clear owner.
+Squads and Tribes would have local scope and understanding and create small samza jobs for their goals.
+But lack of global understanding.
+
+# Lets talk about metadata
+
+- There was no schema repository.
+- there was a convention on topic names.
+    <prod|sandbox|dev>.<service>.<event-name>.<schema>.<message>
+ Types of metadata:
+  - descriptive
+    what does it mean? owner? contains? comes from?
+  - structural
+    how does it relate? how is it sorted? how is organized ?
+  - administrative
+    how far back do we have this?
+    update frequency ?
+    how large?
+    how complete?
+
+    they missed the administrative type of metadata.
+    they missed relationships
+
+Lesson 2:
+ - metadata is critical
+ - especially relationships,
+ - automated please
+ - from the start please
+ - Schema Registries are just a start
+
+# Lesson 3:
+ Kafka topics and events weren't managed enough.. it became hairy, similar to spagettig code problems.
+ (reference to the movie Primer and trying to follow the plot)
+ The solution was to have the Data Engineers design the data streams and Events.
+ (reference to 12 angry man)
+ (reference xkcd #657)
+
+# more problems:
+   Issues wth Samza jobs and bugs and halts
+
+They started to make the API server besides sending to kafka do also:
+ - send biz-events to kinesis-> flink -> S3 (and also to a data catalog)
+ - do data transformations on S3 and register these transformations on the data catalog
+
+# Lesson 4:
+ REPEATABILITY is IMPORTANT
+  - streams must choose between replays and accept errrors as permanent
+  - replays can be complicated
+  - batch processing can be done again anytime
+  - going straight to the archive in small batches get benefits of both.
+
+# Is this Lambda Architecture?
+   (not about aws lambda or lambda functions)
+  this is a system with two "output" flows:
+    - a stream side (kafka, samza, cassandra) (under 60secs)
+    - a batch side (hadoop, athena, impala)   (under 300secs)
+
+    They use very small batches and the latency is quite low (5mins or low)
+
+# Delta Lake
+This is basically (delta.io) a hybrid system that has both stream and batch input and output flows
+
+
+# Key lessons:
+- conways law
+- metadata is critical
+- data eng control the plot line
+- repeatability is important
+- delta lake + structured streaming
+    can bring the benefits of streaming to batch
+

--- a/talks/conferences/2020-qcon-london/day1-talk6-kafka-a-distrubuted-system.txt
+++ b/talks/conferences/2020-qcon-london/day1-talk6-kafka-a-distrubuted-system.txt
@@ -1,0 +1,123 @@
+Tim Berglund
+
+This is about "KAFKA" boyz...
+
+He works for Confluent, they work on Kafka.
+
+This is going to be a primer on how kafka works:
+- replication
+- leader election
+- consumer groups
+
+# Kafka Basics
+- Topics
+This is NOT a queue, this is a LOG, a distributed log. This is an append only file..
+- Events are KV-pairs. (K is a partition key, not an event-id)
+- Events are persistent and have a lifetime of the topic config.
+- Logs have Partitions
+    - an event gets put on a partition, we use consistent-hashing to map the key onto a partition.
+    - no guarantee of global ordering, no need for that (very good rationale, use a 1-partition topic, reduce data-size to fit)
+- Brokers hold partitions.
+    they are leaders for some partitions
+    they are followers on some others
+- There is a replication factor for partitions (default is 3?)
+- Partition Replication:
+    - there is a 1 leader out of all the replicas.
+    - writes/reads go to the leader
+    - the others are just redundancy
+- Producers: they just write to topics, its a client app
+- Consumers: they read from topics.
+    - consuming doesn't delete the message/event.
+    - consumer-groups are scaled out consumers, they are a single group, they divide/shard the topic reading.
+    - there are some thorny consumer-group coordination problems, which is why kafka streams exist..
+        you need some logic to do a stateful consumption of topics across many partitions for an application group
+- Controller: foundational piece.
+    - writes go to the leader
+    - followers ask the leader for new writes
+    - reads always* come from the leader
+        * at some release introduces an assynchronous follower (observer) and you can have a consumer on an observer
+    - producer ack is tunable (is it when leader writes to disk? when others do?..)
+    - consumer can only READ fully replicated data
+
+# what is the controller ?
+    - it is broker, (first one to come up, by default)
+    - monitor all the other brokers
+    - coordinates partition leader election on broker failover
+        single, global coordinator for all partition leaders.
+
+- Electing a controller
+    - /controller path in Zookeeper
+    when a broker boots it writes metadata into that path/file/node
+    first write wins
+    the node/file/path is alive while session is alive
+    When the controler dies (or hangs), session expires and the next broker in line becomes the leader
+
+- Controlled Shutdown
+    SIG_TERM to the broker
+    broker tells the controller : going down
+    Controler kicks off leader-election for each partition this broker is the leader.
+
+- Broker failure:
+    controller initiates the shutdown when broker fails (heartbeats?)
+
+- Replication Basics:
+ - Log is a sequence of records
+ - we replicate each log
+ - 1 leader, N-1 followers
+ - followers query for new records
+
+- In-Sync Replicas (ISR)
+    replicas are in sync if they are within N messages or T seconds behind.
+    by default, in sync if up to 10secs behind.
+    only ISRs are eligible replicas for leader election
+
+- Replication Basics again:
+    ZK knows leader, the epoch and the ISR list
+    the leader knows High Water Mark (HWM), this is the largest LSN that is common to all ISRs
+    (event horizon of "durable records")
+    Messages are readable if their LSN <= HWM.
+
+- Scenario:
+    - 3 replicas, 1 producer, 1 consumer
+    - (and now a bit of acting w/ ppl on stage)
+    - on connect and write to topic the broker you connect will provide:
+        - metadata and partitions of the topic
+        - and then for a single write a partition is selected
+        - the endpoint for the leader is provided so client can write to it.
+    - leader acks messages and assigns an OFFSET to each msg.
+        offsets are monotonically increasing
+    - followers ask leader for msgs
+        followers write down the msg and offsets
+    - consumers connect, bootstrap broker will provide partitions for topic and leader for partition
+    - consumer can only get msgs with offset <= HWM
+
+- Consumer Groups
+    Assign partitions automatically as consumers enter and leave groups
+    Clients decide partition assingment (brokers are stupid)
+    Scale to 10^4 groups and 10^2 consumers per group.
+    Strongly consistent
+
+    - Consumers in group
+    - every broker acts as a controler, 1 controller per group
+    - FindCoordinator
+    - JoinGroup
+    - SyncGroup
+    - Leave? (lost slide)
+- New story on consumer groups, this is tricky to eep up the notes with explanation.
+    group id is the application id
+    there is a _consumer_offsets topic keyed by group-id, this means there is a leader for a partition for this key group-id
+    the leader when sees the first consumer assigns him the leader role to that group-id.
+    SyncGroup(group-id, member-id, group-assignments) -- group is now bootstrapped
+    this guy will decide wwhich consumers are reading which partitions.
+    this consumer must heartbeat to the broker partition leader
+
+    now a new consumer for that group wakes up.
+    finds the leader broker for that secret topic consumption group.
+    bootstrapped and ready to consume
+    can't read yet..
+    when leader consumer heartbeats, is told about other consumer for that group.
+    leader consumer now rebalances partitions across consumers
+    finally consumer-2 starts to find records to consume
+
+
+

--- a/talks/conferences/2020-qcon-london/day2-talk1-tech-leadership-through-underground-railroad.txt
+++ b/talks/conferences/2020-qcon-london/day2-talk1-tech-leadership-through-underground-railroad.txt
@@ -1,0 +1,32 @@
+This talk was focussed on using stories about the Underground Railroad and reinterpret them as tech leadership/management lessons.
+
+Underground Railroad: US (circa 1850) underground movement to free southern slaves and move them to the free north.
+
+# Leadership Lesson 1
+  Prepare your incentives before you need them.
+  This forces you to think about what are the right incentives for your team.
+
+# Leadership Lesson 2
+  Bold Actions set the Tone
+
+  Examples on how to "fix" quickly a org/team problem by setting the tone with a bold action.
+  Example: "standup meetings that are sit-downs that take >40mins" -> removed the chairs from the meeting room to trigger a change.
+
+# Leadership Lesson 3
+  Don't let your experience bias You.
+
+  Don't do things that you are very confortable with but might:
+    - not be the best for the team/project
+    - unfamiliar and 'risky' or hard to your team/project
+
+# Leadership Lesson 4
+  Embrace Continuous Solving
+
+  Don't frett about repeat problems or re-ocurrences, that is just garanteed to happen.
+  Keep "solving" them and repeat the solving exercise..
+
+# Leadership Lesson 5
+  You're a Leader of Leaders
+
+  Be confortable letting the team take on the problems and create solutions
+

--- a/talks/conferences/2020-qcon-london/day2-talk2-evolution-of-finantial-exchange-architectures.txt
+++ b/talks/conferences/2020-qcon-london/day2-talk2-evolution-of-finantial-exchange-architectures.txt
@@ -1,0 +1,175 @@
+This is by Martin Thomson, he gave a first talk at Qcon 10y ago.
+
+# Intro
+10y they could do 100k Tx /sec with 1ms latency
+
+these systems are fantastically good and expert systems at low latency high throughput systems.
+They run on bare metal, and usually try to colocate w/ the stock exchanges, or as close possible.
+
+Currently best exchanges do under 100 microsecs of latency!
+
+Evolution around:
+    - design
+    - resilience
+    - performance
+    - deployment
+
+
+# Design
+    state machines:
+    input * state -> state
+    input * state -> output
+
+    replicated state machines
+        - ordered inputs
+        - deterministic execution
+        - same state & outputs
+
+    ends up building:
+        Distributed Event Log
+
+        many event sourcing systems fail because they aren't done very formally
+
+    We also use: Rich Domain Models (DDDs)
+        Data Structures to relate data and DDDs many developments around building specific DStructures.
+
+    Time & Timers are also a problem area that needs to be well controlled and very well tought out.
+    Many times atomic clocks and hw time-stamping of network packets are involved
+
+    If there are timers, you have to put that in the event-log so that these things are applied deterministically around all replicas.
+    If you have microsec timestamps, thats 1million events per sec on the log.
+
+    Fairness:
+        operating in a rigged game, market makers, exchanges using customer orders and front-ordering their own orders.
+        if there are gateways to the exchange, you can check which is faster, and use the best one all the time.
+        you can also "stuff" other gateways to slow them down to reduce competition.
+        If there's a single GW, no more fooling around gaming the speed of it.
+
+        So now:
+            - single gateway
+            - multiple matching engines (different engines)
+                - sharding by asset classes or similar
+
+    Migration by Asset Class
+    OTC > Exchange Traded (no idea what these things are)
+
+
+# Resilience
+    How do we deal with Fault-Tolerance.
+    10y ago: Primary + Secondary
+        basically, the flawed split brain problem..
+        conversations with layers about Fault-Tolerance, layers can't accept working on "secondary", no redudancy left.
+
+    Consensus
+        evidently they are now adopting consensus systems (funny to these guys 10-15y behind Goog/Amzn)
+        But many are still using primary + secondary, giving silly excuses.
+
+    Lamport - Paxos
+    Barbara Liskov - Viewstamp Replication
+    Ken Birman - Virtual Synchrony
+
+    .. and then a slide on RAFT
+    RAFT is revolutionizing by having a more approachable paper and new implementations popping up.
+
+    - Election Safety
+    - Leader Append-Only
+    - Log Matching
+    - Leader Completeness
+    - State Machine Safety
+
+    So, they are using RAFT now and now follows a simple description of RAFT.
+    for a single consensus module, there is a leader, clients connect to it.
+    Distributed Log, now each node holds
+        - append index
+        - commit index, the known quorum appended
+        - service index, the "DB/application" applied index
+
+    Now he's talking about leader re-election due to a fault and how to avoid the former leader (still thinking it is the leader) from causing issues.
+
+    Importance of Code Quality & Model Fidelity
+    - They are probably now carefully ensuring model-checking and validate fidelity to the formal proof.
+
+
+    Robustness is another approach to Resiliency
+        How to make the software robust to cope with bad input, or other errors.
+        Example: unhandled exceptions or errors.
+
+# Performance
+    This was the highlight 10y.
+
+    Now: latency distribution awakening.
+    We used to track averages, some still do (dinosaurs!) but now full latency histograms, percentile latencies..etc
+
+    systemic & queueing events
+        - GC pauses
+        - SSD block reallocation on the FLT layer
+
+    How to work well on a small burst of 10microsecs, at market start, market end, or special unpredictable events.
+
+    Batching and amortization is important (you cannot have linear correlation between input events and IO for example)
+
+    Garbage Collectors: a whole adventure story of which to use, tuning them, "operating" them, etc..
+        Now the C4-GC from ZuulVM (?) is the leading one now.
+
+    Memory Access Patterns & Data Structures
+        evaluating them and studying cache misses matter.
+        controlling memory dependent access and loads are important, Memory ordering and cache alignment is important.
+        the fastest matching engines are in C because of the control of the memory layout
+
+    Binary Codecs: the finance events are a text-based format.
+        the writting is now on the wall, they are now moving to binary protocols.
+        "its human readable" -> "no, it's a tooling problem, that's what it is"
+
+    Spectre & Meltdown
+        big perf impact and mess.
+        huge costs increase
+        a now game that is going on is: which patches can I *NOT* apply ?
+
+    Greatly increased cost for syscalls, page faults and context-switching.
+        they are seeing higher overheads here and are now more aware of minimizing OS-overhead.
+        Hugepages, NUMA is also an important problem.
+
+    Advances in Hardware
+        SSDs impacted the game for sure, they were a game changer.
+        Optane is also a win, not as big as thought, but better at predictability, tail latency.
+        Networking: advanced hugely..
+        CPUs: not much faster, minimal improvements in latency for the services.
+        So, in summary: huge improvements in throughput, but flat on latency
+
+    New IO APIs
+        BSD sockets have run their course.
+        io_uring on Linux..
+        if io is 1microsec -> your ceiling is 1Million/secs
+
+    Mechanical Sympathy
+        align with hardware
+
+    Does programming language matter?
+        not so much the language but more the culture around the language.
+        for example: Java APIs hurt performance due to too many Allocations and lack of thought about that.
+        C++ and Rust are good choices (no surprises)
+
+        Now there are more polyglot systems: some parts in some lang, some parts in others.
+
+# Deployments
+    Continuous Delivery
+        Secret to that is automation
+
+    Agile?
+        I don't care about standups or not
+        the key is feedback cycles
+
+    Move to 24*7 Operations
+        rolling deployments, snapshots of DBs..
+
+    Flexible Scaling
+        Can you use your deployment tools to deploy the whole stack on your laptop?
+        HW loadbalancer, HW this-that is no longer a good idea because they hurt for these approaches.
+        "What used to take a whole rack you can put in a single server".
+        So now there is more IPC and new APIs for that change, easy to get boxes with 100 cores.
+
+# What will the next 10 years hold?
+    More reactive.
+
+    "the future is already here, it is just not evenly distributed" -- william gibson
+

--- a/talks/conferences/2020-qcon-london/day2-talk3-how-we-were-austronautes-and-noware-mission-control.txt
+++ b/talks/conferences/2020-qcon-london/day2-talk3-how-we-were-austronautes-and-noware-mission-control.txt
@@ -1,0 +1,127 @@
+how we went from being austronaus to being mission control
+
+managing systems in a age of dynamic complexity -- Laura Nolan
+
+# intro
+    co-author of the "the sre book" from google
+    senior staff at slack
+
+# All cloud providers have outages
+    even with full hardcore designs to be fault tolerant to full DC failures, they sometimes have large failures.
+
+    on the other side, a single lowly server, with 4-5y uptimes are not unheard off.
+
+# The old ways
+     configuration by hand
+     load-balancer backend pools statically config
+     no auto scaling
+     ...
+
+# Times have changed
+     Automate everything
+     job orchestration
+     autoscaling
+     routing, failover, balancing traffic
+
+     We have largely succeeded
+
+# other pressures
+    better perf and latency, focus on tail latency
+    reduce toil of managing systems
+    react faster to failure
+    consistent prod (infra as code, no pet systems)
+    reduce compliance risks related to humans accessing prod
+
+# Dynamic control pane architecture pattern
+    basic:
+        a service pool (emits signals)
+        a signal aggregator
+        a controller (reads signals), acts on the service pool
+
+    This is a very common pattern, this is a basic autoscaler, or HPA or whatnot.
+    this is now a core part of your prod system, don't keep this in "janky python"
+
+
+    Now you can also have:
+    a global controller ontop of a multiple set of basic ones that are in distinct DCs or zones..
+    For example a global DNS loadbalancer
+        you can now deal with inbalanced systems and even out the load.
+
+    Another example is Google's global Sw-defined network used for batch/bulk.
+        there is a global optmizer and bandwith broker
+        it receives metrics from zone-local collectors of metrics
+        it acts on Traffic-Engineering servers on each zone
+
+# This is just not automation
+    This is mission-critical systems.
+    This is the automatic operator of the critical systems.
+    "We don't run our systems, these systems run our systems"
+
+    We loose "direct observation" and "mechanical sympathy" with these systems.
+
+# Now lets talk about Control Plane Failures
+    - December 24, 2012, AWS Elastic LB
+    See: https://aws.amazon.com/message/680587
+    accidental deletion of state
+    Full recovery took 24h
+    Post incident action item was: lock down write access to the ELB control plane state
+
+    Operators need mental model of:
+        - how the system works
+        - how the automation system works
+    So, this is 4x harder to do.
+
+    - April 11, 2016, GCE
+    See: https://status.cloud.google.com/incident/compute/16007
+    Full network outage
+    This was a propagation of a IP Anycast that is busted.
+    only when the propagation reached the last good system, the outage starts.
+    so, lack of signals/metrics that things are about to go bad.
+
+    Multiple network control planes that interacted poorly:
+        - canary system
+        - control plane using it
+        - delayed propagation of changes w/ delayed sideeffects
+    Classic complex systems failure involving multible bugs and latent problems
+
+    Testing these systems are a real challenge.
+
+    - June 2, 2019: Google network outage
+     elevated packet loss for 4h25m
+     See: https://status.cloud.google.com/incident/cloud-networking/19009
+
+     Maintenances are common and automated.
+     This is the "usual work" of a network system.
+
+     this is another case of multiple bad things happening, time to detection was fast.
+     time to repair was high becaue the network was in the shit, the global state was damaged with the full outage.
+
+        There was loss a global state that didn't have a "checkpoint" system or similar.
+     (I remember reading this one, and it was a very nasty one..)
+
+
+# Learnings
+    Testing failsafe or fail static behaviour is scary.
+    We're adverse to "fail" systems to run on failsafe just for normal operation.
+    (Imagine if they did, and caused a global outage..exaclty because of a bug on the failsafe..)
+
+    Use regional or zonal control systems.
+    Avoid global systems
+    Reduce blast radius
+    Test your control planes really really hard.
+
+    Plan for time needed for operators to stay familiar with the underlying operations.
+    no matter how much automation, you need a disaster recovery plan, you need to EXERCISE your plans.
+    We need DRILLS.
+    (added by me: Main lisbon's hospital runs every saturday on the power generators to ensure it can run without main power)
+    they DRILL IT WEEKLY!!
+
+    SOMETIMES HUMANS ARE BETTER
+        it is good to not fully automate some things.
+        build tools, but do they need ZERO intervention?
+
+    Make all your control systems to log into the same place.
+        they are working independently, but we need to understand the sequence of events and relate them if needed.
+
+    Have a "KILL SWITCH", consider a "switch to manual"
+

--- a/talks/conferences/2020-qcon-london/day2-talk4-BERT-for-sentiment-analysis.txt
+++ b/talks/conferences/2020-qcon-london/day2-talk4-BERT-for-sentiment-analysis.txt
@@ -1,0 +1,95 @@
+BERT for sentiment analysis on Sustainability Reports
+
+This is from KPMG, they have a sustainable "things" team or something.
+
+# The problem
+    different ppl have diff opinions on the expressed sentiment.
+    very time consuming to find problematic examples.
+    there is also no good comparison we can make.
+
+# Can we quantify the balance?
+    --> SENTIMENT ANALYSIS!
+
+    We tried a LOT of them, different models, comertial:
+        Heaven on demand
+        Rosetta
+        text-processor.com
+      Open source:
+        Stanford Sentiment Treebank
+        Textblob
+      Self-Traind:
+        tf RNN model
+
+    They didn't really work well because of the data used for their training.
+    They used "www.menti.com" to do annotations/classification of data for their reports.
+
+    they had to normalize how to rank the sentiment. Also negative sentiment on public reports is written in "positive" way
+        (we will see improvements on.., new opportunities, or challenges on..)
+
+# BERT
+    Lets start simple
+    Vector representations
+        one hot encoding for a matrix bit, 1 bit per word of a long vector of works
+
+    Word2Vec models: variation of an auto encoder.
+        NN, structure of an hourglass. You try to predict the input itself.
+
+    Word2Vec doesn't work for words w/ multiple meanings (river bank, hsbc bank)
+    Sequence models: predict based on sequence of words
+        basically: RNN
+
+    BERT:
+        Masked Language Modelling (MLM)
+        try to predict a word by masking that word, capturing the context of everything around it.
+        .. she's going quite fast, something about CLS tokens and how they are important for classification..
+
+        They use BERT, with the output that into their own classifier model.
+        BERTbase and BERTlarge
+
+        tinyBERT
+        ALBERT
+        RoBERT
+        CamemBERT
+
+        pytorch, keras, hugging face, ..
+
+# Finetuning BERT for their data
+    ~800 sustainability reports
+    aprox 90 pages each
+    extract all data and split into sentences.
+    didn't do stemming nor lematization
+
+    They don't like tensorflow and ended up building some code on Keras
+    this was before tf-2.0
+
+    ~8000 labelled sentences
+    2days labelled by humans
+    Negative sentiment: only 3%, Positive: 21%, Neutral: 76%
+
+# Results
+Accuracy: 82%
+    Negative: 71%
+    Positive: 80%
+    Neutral: 94%
+
+    it never conflicted neutral with positive, so it was only on adjacent labels
+
+    BERT was able to correctly predict negative sentences that humans didn't spot.
+
+# Back to the problem
+    the analists don't always agree and cant consistently evaluate reports.
+    But BERT was consistent with them and seems to have better consistency than humans.
+    This means bulk sentiment analsysis is now easy to do on the reports.
+
+# Demo
+    PDF parser
+    POS tags
+    Named Entities
+    Sentiment (highlighted color on sentences)
+    Report overview, with topics (probably tf/idf)
+
+
+.. this was a very fast talk, and she skimmed a lot over important bits.
+ My interpretation: this was a very good execution and very smart team, but it was so fast I don't understand the "insight" or learnings.
+
+ NOTE TO SELF: when you do talks, think about what is the LEARNING for your audience

--- a/talks/conferences/2020-qcon-london/day2-talk5-the-ideal-number-of-microservices-is-489.txt
+++ b/talks/conferences/2020-qcon-london/day2-talk5-the-ideal-number-of-microservices-is-489.txt
@@ -1,0 +1,56 @@
+This talk is pun on the tweetstorm that followed when Monzo twitted about their 1500 microservices running in production.
+
+"How can you possibly know what's going on?"
+
+But more seriously: "what would be an appropriate number of services?"
+
+So this panel is about for different companies, how do they view their services in operation and "how many" they have or consider.
+
+Represented are:
+- Finantial Times
+    they have a massive zoo of prog. langs and tools, "if you considered it, we run it"
+    they don't have a company-wide polity or normalization attempt, there some checks and balances but for specific things and is about risk.
+    They do have a catalog of all services (or products?) and the count there is ~150.
+    They run lambdas, containers, servers, VMs,... the whole panoply.
+    They do ask: "do you genuinely deploy these over here separately?"
+    There is independence, FT the website, 5y ago would have 12 releases a year. Nowadays they have 40k releases a year.
+        they know this because they have a "changes" api to track their changes to FT.
+        They now use a continuous delivery approach, short lived branches and small changes.
+
+- Monzo
+    they have a single language: Go, shared tools. They have >1500 microservices.
+    their recommended sweet spot is: if this a specific domain entity and operations on it and a natural bounded context.
+        this is a good microservice and is deployed independently and scaled independently.
+    they have a common FS-tree structure, a single framework and tooling around for their systems.
+    "golden path" approach, free metrics, free structured logging, free distributed tracing.
+        one can get a new service up and running with a DB-entities and APIs in production in 2hours or so.
+    Significant tooling for locating, deploying, learning about code-owners or codebase, or metrics.
+    They also have a monorepo. So all deployments are tracked in a single repository
+
+    A question that does come up: what should be converted into a library ?
+        For that to happen, we're adding another layer of metrics and expertize.
+        We only want to create libraries after writting a given thing a few times to learn about the right APIs it should have.
+
+    What about all the overheads of all the network hops ?
+        big chat about you also don't control latency traits of IO-paths or GC-pauses or other things that can impact your latency
+        so we don't hide that there might be a bit more overhead, but
+
+
+- SkyScanner
+    Around 2Million msg/s
+
+    At this scale, you have to innovate and your past experience "breaks".
+
+    This is not about conventional microservices but more about how you try to "flatten" the amount of 'steps' on processing work.
+
+    also on the metrics is not about the microservices or the events, it is about trends and outliers.
+    The monitoring needs to evolve to track the health of the system in a probabilistic fashion.
+    They've broken "AWS" a few times due to running ~4k containers on ECS just for their logs.. for example.
+        very proud that AWS uses them as a "test" account due to their volume, given they've broken AWS systems before.
+
+    (between Monzo and SkyScanner there's a bit of flaunting and "posing", the FT engineer is more gracious and "wise",
+     not trying to show off)
+
+    Now they're talking about cascading failures due to surges in load knocking 1 region at a time.
+
+Now there's a QA session

--- a/talks/conferences/2020-qcon-london/day2-talk6-the-tesla-virtual-power-plant.txt
+++ b/talks/conferences/2020-qcon-london/day2-talk6-the-tesla-virtual-power-plant.txt
@@ -1,0 +1,155 @@
+This talk is special
+no recording
+no slide sharing
+
+This was secret stuff until now.
+
+# the electric grid is the amazing and beautiful
+
+ prepared speech about how the grid is 20century tech and things are about to change.
+
+ software is key, and now we can create virtual powerplants by using batteries scattered around homes.
+
+ Software is key to clean energy future.
+
+ evolution of the test power plant.
+
+ cloud iot platforms.
+
+ they are not speaking in behalf of tesla, just about their personal experiences.
+
+# How does the grid work ?
+
+ demand and supply must be balanced (all the way to the second?).
+ Generation can't be totally controlled on renewables.
+ In new world a lot of micro-generators (home solar)
+ this means higher inbalances between power generation and demand.
+
+ Batteries can be used to SOAK the inbalance.
+ So.. lets use home batteries.
+
+ Lets walk through the 4 sections of evolution of this .
+
+ 1. Tesla Energy platform
+ 2. Single batt market participation
+ 3. peak shaving virtual power plant
+ 4. market partication virtual power plant.
+
+# Tesla Energy Platform
+ Description of the tesla power wall product.
+ firstly the domestic product.
+ then the industrial one (they also have a tesla battery for this)
+
+    So basically these things have:
+    - IoT Sensors and controllers
+    - Edge Computing Platform (runs linux)
+    - and it talks to the cloud
+
+Layers:
+  IoT devices
+  websocket/PKI
+  kafka + PubSub services
+  Kafka Topics -> cannonicalization and scrubbing/enriching into specific topics.
+
+  (StreamProcesses read these topics and put them in the data stores..)
+  InfluxDB .. || PgSQL .. || PgSQL ..
+  Telemetry, Alerts, Events || Assets & Auth || Command and Control
+         Applications
+
+  They use akka and akka streams, the only thing the user writes are functions.
+  They also use alpakka, they use it to.
+  They use Scala as a prog. language, they have become big fans of Scala for
+  large scale distributed systems with IoTs
+  They run their stuff on Kubernetes, Akka + K8s are a very good pairing, they're very happy with it.
+  they also are now fans of gRPC now.
+
+  "Constraints Liberate, Liberties Constrain" -- some dude
+
+  Principles of Reactive Systems and Reactive Streams.
+
+  a toolkit for distributed computing:
+   state, distribution, streaming
+
+  They're a "strict types" camp.
+  Invest in your toolset.
+
+# A Single Battery Market Participation (100MW?)
+
+  The goal of market participation is to respond to load demand *instantanously*.
+
+  So this is controlled by software: "AutoBidder" is the name of their system.
+  This is built in the applications layer of the platform that was described above.
+
+  This is a workload orchestration platform.
+    input: market data
+        orchestrator -> (forecasting and otimization services are used by it)
+    output: bid service -> market API
+
+    the forecasting and optimization engines are in python (pythorch or what?)
+
+    all the RPCs happen with gRPC (on input/out of orchestrator).
+
+    communication to the forecasting and optimization use: AWS SQS (each has 1 input + 1 output queues)
+    so, they have multiple python workers looking at the queues
+
+
+    Business logic is using immutable facts:
+        - fetchData, telemetry + market data
+        - forecast,
+        - optimize
+    ... they snapshot the state so they cnan resume.
+    full decoupling of logic and state, all logic is in pure functions.
+    the akka framework is managing the snapshotting and the state movement.
+
+    decouple workflow state (actors)
+    from business logic (...)
+
+# Peak Shaving Virtual Power Plant
+
+  Peak shaving is: you bid and buy excess energy generation instead of "dumping it".
+  Note: California doesn't do cross-state energy trading because they don't want "federal laws" butting in.
+  So even bigger incentive to do this in california.
+
+  How do we control thousands of Powerwalls?
+   only the ones that subscribed to this "virtual power plant" thingie, not all of them.
+
+  They do hierchical aggregations of multiple batteries by geographical boundaies or similar.
+  .. this is recursive... all the way to a single node/cell. (a tree or dag)
+  each node off the tree is a Akka actor.
+    it holds some state (like charge state)
+    the tree edges are done through messages between actors.
+
+  They are in varying states of charge, some offline (intermittent fault? network?), etc..
+
+  Management of uncertainty must be implemented into biz logic.
+
+  They have a Akka cluster, that with Akka streams consuming from kafka.
+  Then they have actors computing through messages, they are first delivered to the respective "leaf" actor node for a given battery
+
+  Actors can recover state using "akka persistence", but doesn't need to, because the state is restored when it receives the message from Kafka.
+
+
+  So, Autobidder can be controlling a "node" that represents 10MW or 50MW.
+    the leafs under this node can change dynamically (new batteries, or going offline)
+    so now you send messages to "discharge set point" from the node to the children all the way to the leafs.
+    (so this is how they send commands to the leafs)
+
+  Huge aggregations demand different APIs and data-processing patterns.
+  Assett management is the hardest problem.
+  There is a tention between: central optimization and local-needs
+
+# Market-Participation of the Virtual Power Plant
+
+  So now, autobidder is using the whole tree of nodes/actors.
+
+  "People who are really serious around software need to build their hardware" - Alan Kay
+
+  So, messages to the actors and processing at the nodes to aggregate going up, or divide the order going down the tree.
+  the Autobidder talks to the root-node.
+
+  This automatically handles nodes going out, because we only have actors for alive nodes.
+  The Akka framework system looks like an AMAZING FIT for their problems.
+  There is quite probably a lot of software development to make Akka work this smoothly.
+
+  I have some pics, will try to add them.
+

--- a/talks/conferences/2020-qcon-london/day2-talk7-speeding-up-ML-devel-with-MLflow.txt
+++ b/talks/conferences/2020-qcon-london/day2-talk7-speeding-up-ML-devel-with-MLflow.txt
@@ -1,0 +1,136 @@
+Speeding up machine learning development with MLflow
+
+He works on the AI platform team at LinkedIn.
+
+# Agenda:
+ - unique challenges
+ - ml platform tour
+ - intro of MLflow
+   - demo
+
+# Development Process Overview
+   paper: hidden tech debt in ML systems (paper from Goog)
+
+   we've seen this picture at Unbabel, the 90% of the work for ML is infra-tooling, 10% is ML code
+   configs, data collection, data verification, hw resource mgmt, serving infra, monitoring , etc..
+
+   This is the story of Software 2.0
+   Instead of data driven -> Model driven.
+
+   Sw-devel vs Model-devel
+   Goal:
+    sw: meet requirements
+    model: optimize biz metrics (for us MQM)
+   Quality:
+    sw: depends on code
+    model: depends on data, code, algo, parameters
+   Tool:
+    sw: standard sw stack
+    ...
+    lost slide.
+
+
+    Development dimensions are also different:
+    - there is an experimentation dimension
+     this is scientific endeavor
+
+     the experimentation dimension is what we currently do as a normal practice.
+     this is the work we did for example, to get generic tickets models for transformers for EN-DE.
+
+     Model training is done offline, and then inferencing is done online.
+
+     As your data scales, training costs and time increases polinimially.
+     you need tooling for your training systems.
+
+     ML Platform Tour:
+      you need a whole process and culture.
+
+    Separation of concerns:
+    scientists and ML platform.
+
+    Something common among sw-base and model-base is HABILITY TO ITERATE QUICKLY
+
+# Some platforms that exist out there.
+    - FBLearner
+    - Michelangelo
+    - Google TFX
+    -
+
+    common functionalities:
+     - feature infra
+     - model training
+     - model management
+     - model running
+     - ... lost slide
+     - model monitoring
+
+
+    "major pain points associated with ML project dramatically changes as the scale of the project increases"
+
+    the cloud ones provide pretrained models
+
+
+    ML Services:
+    a layer above infra, that sits on top of k8s, pytorch, gpus, caffe, tensorflow, etc..
+    ML ID, experimentation, training management, monitoring
+
+
+# MLFLOW
+    Open Source ML platform.
+
+    principles:
+     - open
+     - ease of use
+     - extensible
+     - scalable
+    (too many principles, trying to cover everything..)
+
+    manage the ML lifecycle, including experimentation, reproducibility and ..
+
+    What does it give you:
+    - tracking
+    - project
+    - model
+    - model registry
+
+    Tracking
+        record and query experiments, code, configs, results, etc..
+        .. pic of excell sheet to track experiments.. (it's the wild west..)
+
+    .. so it includes:
+     - kv parameters
+     - metrics
+     - artifcats
+     - source code (git url + commit hash..)
+     - version
+     - tags and notes
+    ... connects to notebooks, apps, cloudjobs etc..  w/ APIs
+
+    it holds the artifacts and metadata
+
+    (now he is demoing the UI for running experiments for a project)
+    now he is showing the code used for this, it is basic python normal code,
+    with a few code changes to run the experiment with a `with mlflow.start_run(...) as run: ...`
+    and some extra statements to log some details into the run, like run.with_model("name of the model", filepath)
+
+    Models
+        general format to describe the model
+        this helps the problem of deployment the model
+
+        You can just an API call to register the models that were created.
+        metadata is in yaml.
+
+        this metadata includes a "closure" of the code used to create this model, so this code can be used to run it.
+
+    Model Registry
+        this is to track sharing, versioning, approval
+        centralized activity los and coments.
+        can be integrated with CI/CD
+        model administration and management.
+
+    Model Serving
+        It also has a command line to serve a given model
+        this is to make it very easy to run models
+
+    This talk wasn't very interesting, I don't understand how it is "scalable" or how to extend it
+

--- a/talks/conferences/2020-qcon-london/day3-talk1-interop-of-open-source-tools.txt
+++ b/talks/conferences/2020-qcon-london/day3-talk1-interop-of-open-source-tools.txt
@@ -1,0 +1,93 @@
+Kattie Gumanji
+
+This talk is about the changes in OSS to start to expose APIs and change the way they interoperate.
+
+Example:
+- Docker Swarm
+- Mesos
+- K8s
+
+K8s exposed APIs and created a whole ecosystem around it with lots of different tools popping up.
+
+This is going to be very focussed on k8s, she is a CNCF board commitee member.
+
+# Practical Past
+ - CNI
+  -- the story around here seems to be around good structure/apis and a working ecosystem --
+   Calico
+    has network policies enforcements
+   flannel
+   Cilium
+    gaining momentum
+   weaveNet
+
+ - CRI
+  This case was harder, the way the container execution was done was very intertwined into code and only a
+  specific runtime was the one used at large.
+  It was clear the need for a CRI, abstraction layer over the container runtime execution engine.
+   - containerd
+     industry standard, CNCF project
+   - cri-o
+     lightweight, roughly equivalent to containerd in features
+   - gVisor
+     from google, uses kernel syscall tracing to further isolate
+   - firecracker
+     from AWS, uses HW virtualization and creates effectivly micro-VMs with overhead of 7mb only.
+
+
+# Innovation Wave
+    SMI: service mesh interface
+        normalization of this design pattern of having:
+         infra layer to manage svc2svc traffic within a distributed environ.
+        APIS:
+            traffic policy
+            traffic telemetry
+            traffic management
+        ISTIO
+        LINKERD (incubating CNCF)
+        CONSUL
+
+    CSI: container storage interface
+        plugable interface to consume external storage
+        it is in GA since 1.13
+
+        storageos
+        rook (incubating to CNCF, also uses ceph)
+        ceph
+        OpenEBS
+
+     ClusterAPI: Cluster Provisioning, cloud agnostic
+        kubeadm
+        kubespray
+        kops
+        tectonic
+        (the image on the screen was: turtles on top of turtles)
+
+        What if you want to migrate your cluster between infra providers ?
+        Cross-cloud deployments ?
+        Tool migration ?
+        Challenges: in some regions: like China & Russia, for some reason are on the slides..
+
+        the goal: declarative APIs to declarative create, configure and manage k8s clusters.
+        the current api (in alpha: v1alpha) is supported by google cloud, aws, baidu-cloud, digital ocean, and some little others.
+
+        this needs:
+            cluster ap crds
+            bootstrap providers (like kubeadm)
+            infra providers  (aws, gke, etc..)
+            .. requires a k8s cluster to create clusters.. lol (turtles all the way down)
+
+            CIDRs for pods and services, DNS suffix
+            Machines: kubelet and control plane version
+            MachineSet: declare the Machine/Host resources, it is like a replicaSet or deamonSet
+            MachineDeployment: declare the machine/host cconfigs I guess
+
+# Emergence of Interfaces
+    Extract core binaries and by creating an interface, expose them.
+    Huge impact on vendors, users, community.
+        - space for Innovation
+        - extensibility, space for choice that best fits the user.
+        - interoperability is important for community.
+
+    CloudNative Interfaces has been key for the healthy growth of k8s.
+

--- a/talks/conferences/2020-qcon-london/day3-talk2-design-secure-architectures-the-modern-way.txt
+++ b/talks/conferences/2020-qcon-london/day3-talk2-design-secure-architectures-the-modern-way.txt
@@ -1,0 +1,166 @@
+Some motivation:
+
+How to make security decisions ?
+Is adding security adding more complexity or chaos to your project ?
+How to add security without extra complexity ?
+
+"Designing stack agnostic, modern, secure architectures"
+
+Sounds a bit like the CAP theorem, right ?
+Pick only two ?
+
+1. Stack Agnostic
+ Architecture that is not limited to certain types of infrastructure
+
+2  Modern design approaches, address relevant risks and threat models
+
+3. Secure: .. yup
+
+Step 1:
+Understand goals of security arch. why ? what is the value ?
+..
+
+
+WHY ?
+ story about bank envrionment, with strong security, certifications, etc..
+    but they had crazy high security fraud
+ then they:
+  charged customers per request
+  void contracts for abusers
+
+  --> the managers looked at the risks and addressed the risks.
+  the fix was much simpler than more code and more security features
+
+  Another story about different security problems that got fixed at the architectural level.
+  instead of "security features" or protections suggested by the "security engineer".
+
+Why do large companies still struggle with this?
+ - Equifax
+ - JP Morgan
+ - RSA Security
+ - Operation Aurora victims: google, amazon, etc...
+
+ "Unexecpected attack vector under novel thread model adding to forces that not prepared to meet"
+
+  Humans are unpredictable
+  Technology is broken
+  Poor design decisions <-- this is the one we can have the biggest delta/control/impact.
+
+Security is many times seen negatively:
+ - negative biz value
+ - hard to execute, lots of work
+
+4 types of knowing in security:
+- confusion
+- doubt
+- fear
+- risk averse
+
+More:
+ - too many things to think about
+ - poorly systematized or modeled
+ - abscense of well communicated design principles.
+ ...
+
+ We make more mistakes about risky things under pressre in absence of simple guiding principles
+
+ The remaining 35mins are mental models for you brain to simplify the picture and make decisions easier.
+
+ decisions types/levels:
+  - managers
+  - sw eng
+  - sec engs
+  - architects
+
+  What did google do?
+  revised architecture: beyondcorp.
+
+  Goals of Sec Arch:
+  - understandable and implemented decision system
+  "we don't want a sec-policy that only 3 ppl read fully"
+
+  what is it:
+  combination of sec decisions
+    makes the ACTuAL riSKS manageable in a chosen manner.
+
+    - understand and manage risks
+    - understand and manage attack surface
+    - balance tradeoffs
+
+   before these things, anything is wasted time.
+
+   it is the same as designing for scale, you design to address risks.
+   the risks are different, but the approach is the same.
+
+   NASA way: you make your systems resilient againts the phisics/understandable issues
+   NAVY way: you have attackers and unknown attack vectors.
+
+# RISKS:
+ you need to quantify your risks, so you can manage them. otherwise: FUD
+ valuable approaches:
+  - OWASP RAF
+  - FAIR
+  - NIST RMF
+  - COBIT 5
+  - OCTAVA
+
+  risks are: probability * damage
+
+Understanding the attack surface
+ - any point that an attacker can use to cause a loss
+ attackers look for asset -> they think in graphs
+ defenders protect "boxes/services/systems" -> we think in lists/sets
+
+ to defend: everything must be right
+ to attack: one thing must be wrong.
+
+ - assess, minimize, control, monitor
+ - do DRILLS (validate monitor, control, ..and everything else is adequate)
+
+# Tradeoffs:
+ - risk impact vs cost, usability, maintainability, flexibility
+ - security controls that impact these things greatly are quite probably inefective.
+  you'll have your own team/corp/users trying to circunvent due to the impact it is having on the those attributes.
+
+
+# Designing for Security
+
+  attack surface are ALWAYS too big
+  the only thing it isn't big is your budget
+
+  story about power grid operators
+    huge limitations, legacy systems, mad scale,...
+    ... security ?
+    the sweet intersection of compliance and what the system can be "modified" or "adapted" to do.
+    the tradeoffs were thinking about how the system can expose "how" they are operating into data
+        and do monitoring and analysis of that data.
+
+    Prioritize, think about trust levels:
+     - ultimate "secure"
+     - nothing is "provably secure"
+     - raise the costs and bar of attacks
+     - control the attack flow/points
+
+# tradeoffs, conflicting requirements
+  PCI loggging requirements vs GDPR requirements
+    in some cases legal is the answer.
+
+  general issues around logging and privacy and how logging is also data.
+  no concrete requirements: infinite rabbit hole.
+  what are the logging requirements?
+
+Good architecture is both decision framework and design guide.
+it not only address risks but reduces complexity
+
+When your're focussed on RISKS and attack surface, the tech stack is never the obstacle/issue
+.. an example of "closing down" a old legacy win2k3 AD/LDAP server with: IAM + SSO + ZeroTrust w/ a tiny service in front of legacy system.
+
+# Recap
+ Security Arch is a combination of security decisions, which makes actual system's risks manageable in a chosen manner, efficientl while maintaining all other qualities.
+
+ - risk management
+ - attack surface management
+ - balance tradeoffs, remove conflicts
+
+
+

--- a/talks/conferences/2020-qcon-london/day3-talk3-evolution-of-distributed-systems-on-k8s.txt
+++ b/talks/conferences/2020-qcon-london/day3-talk3-evolution-of-distributed-systems-on-k8s.txt
@@ -1,0 +1,133 @@
+Okay, I can see I won't be able to make rich notes,
+
+    very dense slides with information
+
+    he is talking about requirements of modern systems in terms of non-functional requirements.
+
+# Monolith Applications.
+
+    traditional middleware limitations.
+
+# cloud native architectures
+    the microservices hold business domain logic
+    k8s has native framworks to check:
+     - health, metrics, logs, readiness, liveness, tracing..
+     - managed start/stop, prestart, poststop hooks
+     - declarative deployments, multiple strategies available
+     - declarative resources and automatic placement logic
+
+    it is also easy to run hybrid workloads on k8s.
+    (however the cool kids don't run stateful workloads on k8s.. even though it already supports for quite a while)
+    quoting a friend: "you wanna treat compute like cattle but data are you pets, you wanna control them very closely"
+
+.. okay, this talk is a very good introductory talk about "modern cloud-native architectures" and focussing on the abstractions
+
+  sidecar:
+  - main container, receiving requests
+  - sidecar container, used by main container for some tasks
+
+ now he's covering the controller pattern
+ default schemas, default controllers, managed stateful resources.
+ - examples of custom controllers:
+  - tracking new git-tags for production and triggering a deployment rollout.
+  - tracking changes to config-maps and triggering a deployment rollout
+  (my examples fit into what is called the operator pattern)
+
+# Service Meshes
+    - description of the idea of a service mesh
+# API Gateways
+    Abstract detauls aind decouples consumers from implementations.
+    controlers whats allowed in/out
+    bridges security domains
+    req/resp transforms
+    protocol transforms
+    ...
+
+# Serverless
+    Knative:
+        Service
+        Eventing
+    this is serverless framework for k8s
+    "scale to zero and activation"
+    Service
+        rapid autoscaling
+        traffic splitting
+        callable by knative
+
+    Eventing:
+        sources: kafka, cronjob, apache camel, ..
+        broker impls: kafak, in-mem
+        coud events data format
+        trigger with filters
+        sequence: chaninging multiple steps.
+
+    basically, this is new layer of abstraction to decouple from specific implementations and APIs.
+    this might be useful for us
+
+
+# Darp (what is Dapr?)
+    Distributed systems toolkit as a sidecar
+    building blocks:
+        - actors (logic goes here)
+        - pubsub (secure and scalable messaging between services)
+        - dist tracing
+        - state management
+        - resource bindings
+        - service invocation (reverse poroxy w/ service discovery tracing and error handling)
+
+    this looks very cool, this looks like Akka for k8s
+
+# Full circle:
+    - centralized control plane
+    - decentralized data plane
+
+    knative + istio + k8s
+    dapr + istio + k8s
+
+# Future cloud trends
+
+    Lifecycle trends
+        operator pattern is starting to become popular.
+        see operatorhub.io
+        Operator Framework, for example custom deployments for ML..
+            this is by red hat
+
+    there is a lot happening right now.
+
+
+    Networking Trends
+     Service Mesh Interface spec
+     Arch consolidations of Istio w/ istiod
+     More L7 protocols: MongoDB, DynamoDB, ZooKeeper, Mysql, redis, kafka
+        KIP-559: encryption, filtering, transforms, validation
+     http cache filter (eCache) -- a http caching proxy as a service?
+     http tap filer (w/ matches)
+     webasm filters w/ dynamic loading (C++ -> Rust, Go, etc..)
+
+
+    Binding Trends:
+      Apache Camel (camel3 is integrated into k8s)
+      this is basically "gradle" for build + deploy on k8s, in an integrated fashion
+
+
+    Cloudstate:
+        akka sidecar to your gRPC service that is the actor function
+        the akka sidecars use some data store to keep the state
+
+    Multi-runtime microservices are here:
+    dapr
+    cloudstate
+    knative
+
+    your biz-logic is poliglot and on top of a fat layer of:
+     VMs + k8s + envoy + .. + you-code-here
+
+    Smart sidecars, dump pipes
+     all interactions to the outside world are with sidecars
+
+     He calls this Mecha-architecture
+     he is making the case that faas or serverless are the wrong abstraction level
+
+     biz-logic is in a container, the scaffolding/io/IPC/distributed needs are off the shelf tech
+
+     the closest thing right now is dapr + envoy

--- a/talks/conferences/2020-qcon-london/day3-talk4-N26-hypergrowth.txt
+++ b/talks/conferences/2020-qcon-london/day3-talk4-N26-hypergrowth.txt
@@ -1,0 +1,59 @@
+So, the security on CI/CD talk was very bad and I switched to this talk halfaway.
+
+
+# Releases
+  Around 500 releases per week.
+  continuous investment in Continuous Delivery
+  They have no manual checks after code is commited into master:
+   - dev deploy
+   - automated tests, perf, tc..
+     end to end tests
+     security reports
+
+   - staging deploy
+   - more tests
+   - live canary deploy
+   - more tests
+   - full prod deploy
+   all automated.
+
+  They do "blue/green" on their canary, so:
+   - take 1 node out
+   - put it back with new code
+   - run all integration tests on that node
+   - if it is successfull (and node serves traffic without errors)
+   - deploy to rest of fleet.
+
+   -- this pattern probably means their deployments have a *separate* canary deployment, that way it is easier to automate
+     all the testing and steps and moving the pipeline forward.
+
+# Reliability
+  Goal: high release rate, reduce risk
+
+  avoid incidents is by avoiding changes
+    they are unavoidable
+  so the goal is to minimize the TIME of it.
+    time to detect
+    time to diagnose
+    time to fix
+
+  Blameless postmortem culture
+   they started to routinely evaluate how many incidents they had and what systems or teams did they come from.
+   - written records
+   - incident impact
+   - actions to mitigate
+   - the root cause
+   - preventing actions
+   this was very good for knowledge sharing and documentation of our systems.
+   they also were self-aware of how the incident handling process was working.
+
+   they use the post-mortems on onboarding new engineers.
+   (this is cool)
+
+# lessons learned
+    - adjust to your journey conditions
+    - continous delivery
+    - infra as code
+    - keep availability in mind
+
+

--- a/talks/conferences/2020-qcon-london/day3-talk4-keep-calm-and-secure-your-cicd.txt
+++ b/talks/conferences/2020-qcon-london/day3-talk4-keep-calm-and-secure-your-cicd.txt
@@ -1,0 +1,35 @@
+This is mostly about a specific experience of a company using GitHub and marketplace to improve their CI/CD
+
+by Sonya Moisset, security engineer
+
+she's going over some attacks that are very visible to the world, wannacry, sextorsion, ashley madison, phising attacks.etc..
+
+now about databreaches..how they happen
+
+attacks through scripts that are embedded on sites, because npm/js land has so many deps.. you can target them and try to inject code there. some clueless devs will really accept github PRs that hide security trojan horses.
+
+a cool story of social engineering to gain access to npm packages hosted on github to inject malware/attacks.
+
+my note:-- the problem isn't really npm or js, it just shows there because the SIZE of the community/usage of JS is so large, so large attack surface.
+
+now about OWASP
+it publishes the top10 proactive controls
+    this is very usefull and we should track it.
+    https://owasp.org/www-project-top-ten/
+
+
+Pride London Open Source Project.
+
+they use circleci, github, github marketplace, github actions
+
+use: Gatsby, contentful, webhooks, gatsby cloud for build, netlifly, circleci, codecov,
+    .... this isn't a good talk ....
+
+this is a walk around what they use ...
+
+so, yes, I know security is a problem and I know about known attack vectros
+yes, there are lots of tools to use for a full blown application ci/cd.
+very unstructured on the type of tools and for what purpose
+
+LGTM - automated security reviews
+datree - compliance

--- a/talks/conferences/2020-qcon-london/notes-day1.txt
+++ b/talks/conferences/2020-qcon-london/notes-day1.txt
@@ -1,0 +1,69 @@
+INTRO- 1st TALK
+
+52 talks per day
+
+1 track:
+    - 6 talks,
+    - 1 experience/ama/panel talk
+
+6 tracks
+1 ama track
+2 sponsored tracks
+
+10-1 attendee ratio
+
+Open Space:
+    open space to propose a topic and have a debate around it with other attendees
+
+
+
+# Next Gen Microservices -
+ - Decomposition Patterns
+ - Dist systems are hard
+ - Beyond Distributed Monoligh, reach the big data
+ - Monitoring, keeping track of a Mixed State
+
+# Streaming Data Architectures -
+ - Scalable Cloud Arch, internet of tomatoes, IoT
+ - Streaming milling likes/second, server to client streaming.
+ - Databases and stream processing: future of consolidations.
+    should probably go
+ - From Batch to Streaming to Both
+ - ML through streaming at Lyft
+
+# Driving Full Cycle Engineering Teams at Every Level
+  - Strong Eng. Culture
+  - Operating on what you build
+  - Scaling teams
+  - Journey to Better Quality
+  - Developer Effectiveness, optimizing feedback loops
+
+# When things go Wrong: GDPR, Ethics, Politics
+  - Climate change & Tech
+  - Generative Culture
+  - Mental Wellbeing in Tech (clinical psychologist)
+  - When All the Things Go Wrong (very bad things)
+  - DevOps is more complex and harder than you think
+
+# Modern CS in the Real Wourld
+ - Infinite Parallel Universes: States at the Edge
+  - Peter Bourgon (should go)
+ - Coccinelle: 10y of automated evol of the linux kernel
+ - Record, Replay, Rinse & Repeat: rebuilding Programmetic State
+ - Cloudstate: Towards stateful Serverless
+ - Kafka: Modern Distributed System
+ - Applying AI/ML for Trusted Commerce (facebook)
+
+# Javascript track:
+ - a bunch of stuff on JS, I won't follow it closely, but JS is extremely important for our world.
+ - Bangle.js: smart watch w/ js
+ - Running 3rd-party JS
+ - Node.js serverless apps into prod.
+ - ...
+
+# Speaker AMAs
+  - .. two tracks
+  - won't attend.. for now I think
+
+
+

--- a/talks/conferences/2020-qcon-london/notes-day2.txt
+++ b/talks/conferences/2020-qcon-london/notes-day2.txt
@@ -1,0 +1,59 @@
+INTRO- 1st TALK
+
+52 talks per day
+
+1 track:
+    - 6 talks,
+    - 2 experience/ama/panel talk
+
+
+# Architectures you always wondered about
+    - Evolution of Financial Exchange Arch
+    - Managed Systems in the Age of Dynamic Complexity
+    - Lessons from DAZN: Scaling your Project with Micro-Frontends
+    - Rethinking the Linux Kernel
+    - Tesla Virtual Power Plant
+    - Designing a Real-Time Global Sportsbook (from scratch!)
+
+# Building High Performing Teams
+    - My Team is High Performing But Everyone hates us
+    - How to Debug your Team
+    - Trust, the secret ingredient in High Performing Team
+    - How t Supercharge a Team with Delegation
+    - The good, bad, ugly: making teams perform better
+    - Optimise for Time
+
+# Machine Learning: The latest innovations
+    - Accuracy as a Failure
+    - Visual intro into Machine Learning and Deep Learning
+    - BERT for Sentiment Analysis on Sustainability Reporting
+    - Fast track to AI wi JS and serverlerss
+    - Speeding up ML Development with MLFlow
+    - ML Open Space
+
+# Future of the API: REST, gRPC, GraphQL and More
+    - Brief History of the Future of the API
+    - Future of Cloud Native API Gateways
+    - Moving beyond request-reply, how Smart APIs are different
+    - Next Gen Client APIs in Envoy Mobile
+    - Introducing and Scaling a GraphQL BFF
+    - Panel: how to make the Future your Present
+
+# Modern Compilation Targets
+    - The modern Platform in 2020
+    - TornadoVM: Java for GPUs and FPGAs
+    - Build your own WebAssembly Compiler
+    - Tiny Go: Small is Going Big
+    - Pony, Types and GC
+    - Modern Compilation Targets Open Space
+
+# Bare Knuckle Performance
+    - Quarkus: new Java stack
+    - Does Java need Inline Types? Project Valhala
+    - Perf vs New Features: doesn't have to be zero-sum
+    - GraalVM: maximizing perf with GraalVM
+    - Understanding CPU uarch to increase perf
+    - Perf Open Space
+
+# Speaker AMAs:
+    - a bunch of them..


### PR DESCRIPTION
## Summary

Import notes from https://github.com/msf/notes and organize them into the site.

## Changes

### New Directory Structure



### README Updates

Added new sections:
- **Technical Papers & Study Notes** - Links to EVM and Snowflake papers
- **Conference Talks & Notes** - Link to QCon London 2020 notes

## Motivation

The notes repo contains valuable technical content that should be more accessible. This organizes them into a discoverable structure on the main site.