### PR TITLE
fix: Part 3 nav bar, rename Part 2 title to WHY

### DIFF
--- a/blogpost/local-llm-coding-harder-test.md
+++ b/blogpost/local-llm-coding-harder-test.md
@@ -2,7 +2,7 @@
 
 *April 2026*[^1]
 
-*Previous: [I benchmarked 8 local LLMs writing Go on my Framework 13](benchmarking-local-llms-go-coding.md)*
+*Part 3/3 — **Part 3** ← [Part 2](local-llm-performance-framework13.md) ← [Part 1](benchmarking-local-llms-go-coding.md)*
 
 [^1]: Co-authored with Claude Opus 4.6.
 

--- a/blogpost/local-llm-performance-framework13.md
+++ b/blogpost/local-llm-performance-framework13.md
@@ -1,4 +1,4 @@
-# This is how SLOW Local LLMs Are On My Framework 13 AMD Strix Point
+# WHY Are Local LLMs So Slow On My Framework 13 AMD Strix Point
 
 *February 2026 -- co-authored with Claude Opus 4.6.
 


### PR DESCRIPTION
## Fixes

- **Part 3**: Added missing nav bar: `**Part 3** ← Part 2 ← Part 1`
- **Part 2**: Renamed title to `WHY Are Local LLMs So Slow On My Framework 13 AMD Strix Point`