### PR TITLE
blog: visually separate stacked posts on section list pages

### DIFF
--- a/content/papers/evm-foundations.md
+++ b/content/papers/evm-foundations.md
@@ -4,8 +4,6 @@ date = "2025-01-01"
 description = "Mental models of EVM execution, storage, state, and gas — validated by real traces on your node."
 +++
 
-# EVM Foundations (Days 1–7)
-
 > Goal: build solid mental models of EVM execution, storage, state, and gas—validated by small, real traces on your node.
 
 ---

--- a/content/papers/snowflake-paper.md
+++ b/content/papers/snowflake-paper.md
@@ -4,8 +4,6 @@ date = "2023-01-01"
 description = "Notes on the Snowflake SIGMOD paper and Andy Pavlo's CMU lecture."
 +++
 
-# Snowflake Paper and Architecture Review
-
 - [Snowflake Paper (PDF)](/papers/snowflake-sigmod-2016.pdf) — SIGMOD 2016
 - Andy Pavlo's lecture from spring 2023:
   - [YouTube lecture](https://www.youtube.com/watch?v=bveqnSk15JQ)

--- a/content/post/benchmarking-local-llms-go-coding.md
+++ b/content/post/benchmarking-local-llms-go-coding.md
@@ -3,8 +3,6 @@ title: "I benchmarked 8 local LLMs writing Go on my Framework 13 AMD Strix Point
 date: 2026-04-10T17:04:51+01:00
 ---
 
-# I benchmarked 8 local LLMs writing Go on my Framework 13 AMD Strix Point
-
 *Part 1/4 — [Part 4](https://blog.mfilipe.eu/post/benchmarking_llms-v3-rebuild/) ← [Part 3](https://blog.mfilipe.eu/post/local-llm-coding-harder-test/) ← [Part 2](https://blog.mfilipe.eu/post/local-llm-performance-framework13/) ← **Part 1** (Feb 2025)*
 
 I have a Framework 13 with a Ryzen AI 370HX and a bunch of GGUF models accumulating in `~/.cache/llama.cpp/`. I wanted to know if any of them can actually write Go that compiles and runs. Not vibes, not leaderboard numbers -- `go build` says yes or no. Goal was to have some sense of where local models are in terms of practical capability, being limited in size and available ram/compute

--- a/content/post/benchmarking_llms-v3-rebuild.md
+++ b/content/post/benchmarking_llms-v3-rebuild.md
@@ -3,8 +3,6 @@ title: "Testing LLMs is hard, doubly hard when the testplan and code are vibecod
 date: 2026-05-07T22:59:29+01:00
 ---
 
-# Testing LLMs is hard, doubly hard when the testplan and code are vibecoded
-
 *Part 4/4 — **Part 4** ← [Part 3](https://blog.mfilipe.eu/post/local-llm-coding-harder-test/) ← [Part 2](https://blog.mfilipe.eu/post/local-llm-performance-framework13/) ← [Part 1](https://blog.mfilipe.eu/post/benchmarking-local-llms-go-coding/)*
 
 *May 2026 — co-authored with Gemma 4*
@@ -62,5 +60,6 @@ We assumed a shell-script wrapper was sufficient for complex behavioral testing.
 ***
 
 **Footnote:**
+- All models were run with **reasoning disabled**. Worth a follow-up exam with reasoning enabled to see how much it moves the needle — especially for Qwen 3.5 / 3.6, which lean heavily on chain-of-thought.
 - Still surprised Qwen 3.6 didn't score better; Gemma 4 totally kicked butt on this test.
 - *vibecoded on hermes + gemma4 models*

--- a/content/post/blogpost-improving-dune-API.md
+++ b/content/post/blogpost-improving-dune-API.md
@@ -3,8 +3,6 @@ title: "How we've improved Dune API using DuckDB"
 date: 2024-08-01T12:22:38-07:00
 ---
 
-# How we've improved Dune API using DuckDB
-
 At [Dune](https://dune.com), we value our customers’ feedback and are committed to continuously improving our services. This is the story of how a simple, prioritized feature request for [DuneAPI](https://dune.com/product/api) —supporting query result pagination for larger results—evolved into a comprehensive improvement involving the adoption of [DuckDB](https://duckdb.org) at Dune.
 
 [![Dune API](blogpost-duneapi-build-tools.png)](https://dune.com/product/api)

--- a/content/post/local-llm-coding-harder-test.md
+++ b/content/post/local-llm-coding-harder-test.md
@@ -3,8 +3,6 @@ title: "Gemma 4 vs Qwen3.5: benchmarking quantized local LLMs on Go coding"
 date: 2026-04-10T17:04:51+01:00
 ---
 
-# Gemma 4 vs Qwen3.5: benchmarking quantized local LLMs on Go coding
-
 *April 2026*[^1]
 
 *Part 3/4 — [Part 4](https://blog.mfilipe.eu/post/benchmarking_llms-v3-rebuild/) ← **Part 3** ← [Part 2](https://blog.mfilipe.eu/post/local-llm-performance-framework13/) ← [Part 1](https://blog.mfilipe.eu/post/benchmarking-local-llms-go-coding/)*

--- a/content/post/local-llm-performance-framework13.md
+++ b/content/post/local-llm-performance-framework13.md
@@ -3,8 +3,6 @@ title: "WHY Are Local LLMs So Slow On My Framework 13 AMD Strix Point"
 date: 2026-04-10T21:01:28Z
 ---
 
-# WHY Are Local LLMs So Slow On My Framework 13 AMD Strix Point
-
 *February 2026 -- co-authored with Claude Opus 4.6.
 
 *Part 2/4 — [Part 4](https://blog.mfilipe.eu/post/benchmarking_llms-v3-rebuild/) ← [Part 3](https://blog.mfilipe.eu/post/local-llm-coding-harder-test/) ← **Part 2** ← [Part 1](https://blog.mfilipe.eu/post/benchmarking-local-llms-go-coding/)*

--- a/layouts/partials/lang.html
+++ b/layouts/partials/lang.html
@@ -1,0 +1,3 @@
+{{- /* Suppress risotto's terminal-style language switcher.
+       Single-language site — no value showing "$ echo $LANG / English"
+       on every page footer. */ -}}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -2,6 +2,15 @@
  * Loaded after risotto.css.
  */
 
+/* Section list pages (post/papers/talks): visually separate entries.
+ * Without this, each article's summary runs straight into the next
+ * article's heading. */
+article.post + article.post {
+    margin-top: 2.5rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--off-fg);
+}
+
 /* Move the "about" sidebar from the right column to a full-width footer band
  * below the main content. Reclaims horizontal space on wide screens. */
 @media (min-width: 45rem) {

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -49,4 +49,17 @@ article.post + article.post {
         margin: 0.5rem 0 0;
         list-style: none;
     }
+    /* The site title "Miguel Filipe" is already in the header and footer.
+     * In the bottom-band aside it's a third repetition — hide it. */
+    .page__aside .about__title {
+        display: none;
+    }
+    /* The aside__content block only repeats info that's already in the
+     * page body or post header (description, date, TOC).
+     * In the bottom-band layout it adds clutter without value — kill it
+     * and the divider that precedes it. */
+    .page__aside hr,
+    .page__aside .aside__content {
+        display: none;
+    }
 }


### PR DESCRIPTION
Adds 2.5rem margin + 1px top border between consecutive `article.post` entries so post summaries don't run into the next post's heading on /post/, /papers/, /talks/.