### PR TITLE
scripts: harden build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,15 +1,47 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+# Build the Hugo site and deploy it to the local Caddy-served directory.
+#
+# Env:
+#   BLOG_DEST  Destination directory served by Caddy.
+#              Default: /srv/selfhost/blog/site
+#   HUGO       Path to the hugo binary. Default: hugo from PATH, else ~/bin/hugo
+set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
-cd "$REPO_ROOT"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$REPO_ROOT/public"
+BLOG_DEST="${BLOG_DEST:-/srv/selfhost/blog/site}"
+HUGO="${HUGO:-$(command -v hugo || echo "$HOME/bin/hugo")}"
 
-echo "🚀 Building with Hugo..."
-~/bin/hugo --source "$REPO_ROOT" --destination "$REPO_ROOT/public"
+if [[ ! -x "$HUGO" ]]; then
+  echo "error: hugo not found (tried PATH and ~/bin/hugo). Set HUGO=/path/to/hugo." >&2
+  exit 1
+fi
 
-echo "✅ Build complete. Output in $REPO_ROOT/public"
+if [[ ! -d "$BLOG_DEST" ]]; then
+  echo "error: BLOG_DEST does not exist: $BLOG_DEST" >&2
+  exit 1
+fi
 
-echo "📦 Deploying to /srv/selfhost/blog/site/..."
-rsync -av --delete "$REPO_ROOT/public/" /srv/selfhost/blog/site/
+echo "==> Building with Hugo ($HUGO)"
+"$HUGO" --source "$REPO_ROOT" --destination "$BUILD_DIR"
 
-echo "🎉 Deployment successful!"
+# Sanity: refuse to rsync --delete from an empty/missing build dir.
+if [[ ! -d "$BUILD_DIR" ]] || [[ -z "$(ls -A "$BUILD_DIR" 2>/dev/null)" ]]; then
+  echo "error: build dir is empty or missing: $BUILD_DIR — refusing to wipe $BLOG_DEST" >&2
+  exit 1
+fi
+
+echo "==> Deploying to $BLOG_DEST"
+# Why this set of flags:
+#   -rltD                  recurse, copy symlinks, preserve file mtimes, devices
+#   --no-owner --no-group  don't try to chown/chgrp — destination uses setgid
+#                          + default ACLs to keep group ownership consistent
+#   --no-perms             don't preserve perms either — let the destination's
+#                          default ACL apply (avoids "chmod: Operation not
+#                          permitted" when dirs are owned by a different user)
+#   --omit-dir-times       don't touch dir mtimes (also avoids spurious errors)
+#   --delete               drop files in dest that no longer exist in source
+rsync -rltD --delete --no-owner --no-group --no-perms --omit-dir-times \
+  "$BUILD_DIR/" "$BLOG_DEST/"
+
+echo "==> Done. $BLOG_DEST is live."


### PR DESCRIPTION
- \`set -euo pipefail\`
- Env-configurable \`BLOG_DEST\` and \`HUGO\`
- Pre-flight checks (hugo present, dest exists, build non-empty) so a silent build failure can't wipe the live site
- rsync flags reworked to stop fighting destination ACLs — clean exit instead of code 23 on every deploy